### PR TITLE
Stopped with status

### DIFF
--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -1865,6 +1865,17 @@ void Dobby::onContainerStopped(int32_t cd, const ContainerId& id, int status)
                      DOBBY_CTRL_EVENT_STOPPED);
     }
 
+
+    //Fire off a notification with status
+    if(!mIpcService->emitSignal(AI_IPC::Signal(mObjectPath,
+                                                DOBBY_CTRL_INTERFACE,
+                                                DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS),
+                                 { cd, id.str(), int32_t(status) }))
+    {
+        AI_LOG_ERROR("failed to emit '%s' signal",
+                     DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS);
+    }
+
     AI_LOG_MILESTONE("container '%s'(%d) stopped (status 0x%04x)", id.c_str(),
                      cd, status);
 

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -1856,6 +1856,18 @@ void Dobby::onContainerStopped(int32_t cd, const ContainerId& id, int status)
     // Regardless of whether of the not the hooks executed successfully
     // we fire off a notification event indicating that the container
     // has stopped.
+
+    // Fire off a notification with status
+    if (!mIpcService->emitSignal(AI_IPC::Signal(mObjectPath,
+                                                DOBBY_CTRL_INTERFACE,
+                                                DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS),
+                                 { cd, id.str(), int32_t(status) }))
+    {
+        AI_LOG_ERROR("failed to emit '%s' signal",
+                     DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS);
+    }
+
+    //Fire off a normal notification
     if (!mIpcService->emitSignal(AI_IPC::Signal(mObjectPath,
                                                 DOBBY_CTRL_INTERFACE,
                                                 DOBBY_CTRL_EVENT_STOPPED),
@@ -1863,17 +1875,6 @@ void Dobby::onContainerStopped(int32_t cd, const ContainerId& id, int status)
     {
         AI_LOG_ERROR("failed to emit '%s' signal",
                      DOBBY_CTRL_EVENT_STOPPED);
-    }
-
-
-    //Fire off a notification with status
-    if(!mIpcService->emitSignal(AI_IPC::Signal(mObjectPath,
-                                                DOBBY_CTRL_INTERFACE,
-                                                DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS),
-                                 { cd, id.str(), int32_t(status) }))
-    {
-        AI_LOG_ERROR("failed to emit '%s' signal",
-                     DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS);
     }
 
     AI_LOG_MILESTONE("container '%s'(%d) stopped (status 0x%04x)", id.c_str(),

--- a/protocol/include/DobbyProtocol.h
+++ b/protocol/include/DobbyProtocol.h
@@ -58,6 +58,7 @@
 #define DOBBY_CTRL_METHOD_LIST                      "List"
 #define DOBBY_CTRL_EVENT_STARTED                    "Started"
 #define DOBBY_CTRL_EVENT_STOPPED                    "Stopped"
+#define DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS        "StoppedWithStatus"
 
 #define DOBBY_DEBUG_INTERFACE                   DOBBY_SERVICE ".debug1"
 #define DOBBY_DEBUG_METHOD_CREATE_BUNDLE            "CreateBundle"


### PR DESCRIPTION
### Description
This PR add a new event called DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS. This event has an additional parameter i.e. the return code of the app. This event is fired after DOBBY_CTRL_EVENT_STOPPED event. Client code could choose to subscribe to any of the 2 events. The DobbyProxy is currently still subscribed to the DOBBY_CTRL_EVENT_STOPPED event.